### PR TITLE
Make LdapFieldNames optional and rename attributes

### DIFF
--- a/deploy/helm/commons-operator/crds/crds.yaml
+++ b/deploy/helm/commons-operator/crds/crds.yaml
@@ -61,14 +61,19 @@ spec:
                           description: Hostname of the LDAP server
                           type: string
                         ldapFieldNames:
+                          default:
+                            uid: uid
+                            group: memberof
+                            givenName: givenName
+                            surname: sn
+                            email: mail
                           description: The name of the LDAP object fields
-                          nullable: true
                           properties:
                             email:
                               default: mail
                               description: The name of the email field
                               type: string
-                            firstname:
+                            givenName:
                               default: givenName
                               description: The name of the firstname field
                               type: string
@@ -76,7 +81,7 @@ spec:
                               default: memberof
                               description: The name of the group field
                               type: string
-                            lastname:
+                            surname:
                               default: sn
                               description: The name of the lastname field
                               type: string

--- a/deploy/helm/commons-operator/crds/crds.yaml
+++ b/deploy/helm/commons-operator/crds/crds.yaml
@@ -62,24 +62,25 @@ spec:
                           type: string
                         ldapFieldNames:
                           description: The name of the LDAP object fields
+                          nullable: true
                           properties:
-                            emailField:
+                            email:
                               default: mail
                               description: The name of the email field
                               type: string
-                            firstnameField:
+                            firstname:
                               default: givenName
                               description: The name of the firstname field
                               type: string
-                            groupField:
+                            group:
                               default: memberof
                               description: The name of the group field
                               type: string
-                            lastnameField:
+                            lastname:
                               default: sn
                               description: The name of the lastname field
                               type: string
-                            uidField:
+                            uid:
                               default: uid
                               description: The name of the username field
                               type: string
@@ -151,7 +152,6 @@ spec:
                           type: object
                       required:
                         - hostname
-                        - ldapFieldNames
                       type: object
                   type: object
               required:

--- a/deploy/manifests/crds.yaml
+++ b/deploy/manifests/crds.yaml
@@ -64,24 +64,25 @@ spec:
                           type: string
                         ldapFieldNames:
                           description: The name of the LDAP object fields
+                          nullable: true
                           properties:
-                            emailField:
+                            email:
                               default: mail
                               description: The name of the email field
                               type: string
-                            firstnameField:
+                            firstname:
                               default: givenName
                               description: The name of the firstname field
                               type: string
-                            groupField:
+                            group:
                               default: memberof
                               description: The name of the group field
                               type: string
-                            lastnameField:
+                            lastname:
                               default: sn
                               description: The name of the lastname field
                               type: string
-                            uidField:
+                            uid:
                               default: uid
                               description: The name of the username field
                               type: string
@@ -153,7 +154,6 @@ spec:
                           type: object
                       required:
                         - hostname
-                        - ldapFieldNames
                       type: object
                   type: object
               required:

--- a/deploy/manifests/crds.yaml
+++ b/deploy/manifests/crds.yaml
@@ -63,14 +63,19 @@ spec:
                           description: Hostname of the LDAP server
                           type: string
                         ldapFieldNames:
+                          default:
+                            uid: uid
+                            group: memberof
+                            givenName: givenName
+                            surname: sn
+                            email: mail
                           description: The name of the LDAP object fields
-                          nullable: true
                           properties:
                             email:
                               default: mail
                               description: The name of the email field
                               type: string
-                            firstname:
+                            givenName:
                               default: givenName
                               description: The name of the firstname field
                               type: string
@@ -78,7 +83,7 @@ spec:
                               default: memberof
                               description: The name of the group field
                               type: string
-                            lastname:
+                            surname:
                               default: sn
                               description: The name of the lastname field
                               type: string

--- a/rust/crd/src/authentication.rs
+++ b/rust/crd/src/authentication.rs
@@ -104,7 +104,7 @@ impl LdapFieldNames {
 
 impl Default for LdapFieldNames {
     fn default() -> Self {
-        LdapFieldNames{
+        LdapFieldNames {
             uid: Self::default_uid(),
             group: Self::default_group(),
             given_name: Self::default_given_name(),

--- a/rust/crd/src/authentication.rs
+++ b/rust/crd/src/authentication.rs
@@ -43,7 +43,8 @@ pub struct LdapAuthenticationProvider {
     #[serde(default)]
     pub search_filter: String,
     /// The name of the LDAP object fields
-    pub ldap_field_names: Option<LdapFieldNames>,
+    #[serde(default)]
+    pub ldap_field_names: LdapFieldNames,
     /// In case you need a special account for searching the LDAP server you can specify it here
     pub bind_credentials: Option<SecretClassVolume>,
     /// Use a TLS connection. If not specified no TLS will be used
@@ -69,11 +70,11 @@ pub struct LdapFieldNames {
     #[serde(default = "LdapFieldNames::default_group")]
     pub group: String,
     /// The name of the firstname field
-    #[serde(default = "LdapFieldNames::default_firstname")]
-    pub firstname: String,
+    #[serde(default = "LdapFieldNames::default_given_name")]
+    pub given_name: String,
     /// The name of the lastname field
-    #[serde(default = "LdapFieldNames::default_lastname")]
-    pub lastname: String,
+    #[serde(default = "LdapFieldNames::default_surname")]
+    pub surname: String,
     /// The name of the email field
     #[serde(default = "LdapFieldNames::default_email")]
     pub email: String,
@@ -88,15 +89,27 @@ impl LdapFieldNames {
         "memberof".to_string()
     }
 
-    fn default_firstname() -> String {
+    fn default_given_name() -> String {
         "givenName".to_string()
     }
 
-    fn default_lastname() -> String {
+    fn default_surname() -> String {
         "sn".to_string()
     }
 
     fn default_email() -> String {
         "mail".to_string()
+    }
+}
+
+impl Default for LdapFieldNames {
+    fn default() -> Self {
+        LdapFieldNames{
+            uid: Self::default_uid(),
+            group: Self::default_group(),
+            given_name: Self::default_given_name(),
+            surname: Self::default_surname(),
+            email: Self::default_email(),
+        }
     }
 }

--- a/rust/crd/src/authentication.rs
+++ b/rust/crd/src/authentication.rs
@@ -43,7 +43,7 @@ pub struct LdapAuthenticationProvider {
     #[serde(default)]
     pub search_filter: String,
     /// The name of the LDAP object fields
-    pub ldap_field_names: LdapFieldNames,
+    pub ldap_field_names: Option<LdapFieldNames>,
     /// In case you need a special account for searching the LDAP server you can specify it here
     pub bind_credentials: Option<SecretClassVolume>,
     /// Use a TLS connection. If not specified no TLS will be used
@@ -63,40 +63,40 @@ impl LdapAuthenticationProvider {
 #[serde(rename_all = "camelCase")]
 pub struct LdapFieldNames {
     /// The name of the username field
-    #[serde(default = "LdapFieldNames::default_uid_field")]
-    pub uid_field: String,
+    #[serde(default = "LdapFieldNames::default_uid")]
+    pub uid: String,
     /// The name of the group field
-    #[serde(default = "LdapFieldNames::default_group_field")]
-    pub group_field: String,
+    #[serde(default = "LdapFieldNames::default_group")]
+    pub group: String,
     /// The name of the firstname field
-    #[serde(default = "LdapFieldNames::default_firstname_field")]
-    pub firstname_field: String,
+    #[serde(default = "LdapFieldNames::default_firstname")]
+    pub firstname: String,
     /// The name of the lastname field
-    #[serde(default = "LdapFieldNames::default_lastname_field")]
-    pub lastname_field: String,
+    #[serde(default = "LdapFieldNames::default_lastname")]
+    pub lastname: String,
     /// The name of the email field
-    #[serde(default = "LdapFieldNames::default_email_field")]
-    pub email_field: String,
+    #[serde(default = "LdapFieldNames::default_email")]
+    pub email: String,
 }
 
 impl LdapFieldNames {
-    fn default_uid_field() -> String {
+    fn default_uid() -> String {
         "uid".to_string()
     }
 
-    fn default_group_field() -> String {
+    fn default_group() -> String {
         "memberof".to_string()
     }
 
-    fn default_firstname_field() -> String {
+    fn default_firstname() -> String {
         "givenName".to_string()
     }
 
-    fn default_lastname_field() -> String {
+    fn default_lastname() -> String {
         "sn".to_string()
     }
 
-    fn default_email_field() -> String {
+    fn default_email() -> String {
         "mail".to_string()
     }
 }


### PR DESCRIPTION
## Description

Attributes of `LdapFieldName` have default values but the whole struct must be optional.
Also removed the `_field` suffix as it is redundant.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
