### PR TITLE
Add restart controller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -282,6 +282,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dyn-clone"
@@ -411,6 +417,12 @@ dependencies = [
 
 [[package]]
 name = "futures"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
+
+[[package]]
+name = "futures"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
@@ -486,6 +498,7 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
+ "futures 0.1.31",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -527,6 +540,15 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "heck"
@@ -650,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -754,7 +776,7 @@ dependencies = [
  "chrono",
  "dirs-next",
  "either",
- "futures",
+ "futures 0.3.21",
  "http",
  "http-body",
  "hyper",
@@ -819,7 +841,7 @@ dependencies = [
  "ahash",
  "backoff",
  "derivative",
- "futures",
+ "futures 0.3.21",
  "json-patch",
  "k8s-openapi",
  "kube-client",
@@ -1466,6 +1488,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
+name = "snafu"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eba135d2c579aa65364522eb78590cdf703176ef71ad4c32b00f58f7afb2df5"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a7fe9b0669ef117c5cabc5549638528f36771f058ff977d7689deb517833a75"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "socket2"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1491,10 +1535,14 @@ dependencies = [
  "anyhow",
  "built",
  "clap",
+ "futures 0.3.21",
  "serde",
+ "serde_json",
  "serde_yaml",
+ "snafu",
  "stackable-commons-crd",
  "stackable-operator",
+ "strum",
  "tokio",
 ]
 
@@ -1509,7 +1557,7 @@ dependencies = [
  "const_format",
  "derivative",
  "either",
- "futures",
+ "futures 0.3.21",
  "json-patch",
  "k8s-openapi",
  "kube",
@@ -1549,7 +1597,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -1863,6 +1911,12 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-xid"

--- a/deploy/helm/commons-operator/templates/roles.yaml
+++ b/deploy/helm/commons-operator/templates/roles.yaml
@@ -10,7 +10,6 @@ rules:
       - pods
       - configmaps
       - secrets
-      - secrets
     verbs:
       - get
       - list

--- a/deploy/helm/commons-operator/templates/roles.yaml
+++ b/deploy/helm/commons-operator/templates/roles.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-clusterrole
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - configmaps
+      - secrets
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+      - patch # We need to add a label to the StatefulSet
+  - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create

--- a/deploy/manifests/roles.yaml
+++ b/deploy/manifests/roles.yaml
@@ -1,0 +1,33 @@
+---
+# Source: commons-operator/templates/roles.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: commons-operator-clusterrole
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - configmaps
+      - secrets
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+      - patch # We need to add a label to the StatefulSet
+  - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create

--- a/deploy/manifests/roles.yaml
+++ b/deploy/manifests/roles.yaml
@@ -11,7 +11,6 @@ rules:
       - pods
       - configmaps
       - secrets
-      - secrets
     verbs:
       - get
       - list

--- a/deploy/manifests/roles.yaml
+++ b/deploy/manifests/roles.yaml
@@ -1,5 +1,4 @@
 ---
-# Source: commons-operator/templates/roles.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -10,10 +10,14 @@ repository = "https://github.com/stackabletech/commons-operator"
 [dependencies]
 anyhow = "1.0"
 clap = "3.1"
+futures = { version = "0.3", features = ["compat"] }
 serde = "1.0"
+serde_json = "1.0"
 serde_yaml = "0.8"
+snafu = "0.7"
 stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.15.0" }
 stackable-commons-crd = { path = "../crd" }
+strum = { version = "0.24", features = ["derive"] }
 tokio = { version = "1.17", features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -1,3 +1,5 @@
+mod restart_controller;
+
 use stackable_operator::cli::Command;
 
 use clap::Parser;
@@ -23,7 +25,21 @@ async fn main() -> anyhow::Result<()> {
     match opts.cmd {
         Command::Crd => println!("{}", serde_yaml::to_string(&AuthenticationClass::crd())?,),
         Command::Run(_) => {
-            todo!();
+            stackable_operator::utils::print_startup_string(
+                built_info::PKG_DESCRIPTION,
+                built_info::PKG_VERSION,
+                built_info::GIT_VERSION,
+                built_info::TARGET,
+                built_info::BUILT_TIME_UTC,
+                built_info::RUSTC_VERSION,
+            );
+
+            let client = stackable_operator::client::create_client(Some(
+                "commons.stackable.tech".to_string(),
+            ))
+                .await?;
+
+            restart_controller::start(&client).await?
         }
     }
 

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -37,7 +37,7 @@ async fn main() -> anyhow::Result<()> {
             let client = stackable_operator::client::create_client(Some(
                 "commons.stackable.tech".to_string(),
             ))
-                .await?;
+            .await?;
 
             restart_controller::start(&client).await?
         }

--- a/rust/operator-binary/src/restart_controller.rs
+++ b/rust/operator-binary/src/restart_controller.rs
@@ -43,9 +43,9 @@ enum Error {
         obj_ref: ObjectRef<DynamicObject>,
     },
     #[snafu(display("configmaps were not yet loaded"))]
-    ConfigMapsUninited,
+    ConfigMapsUninitialized,
     #[snafu(display("secrets were not yet loaded"))]
-    SecretsUninited,
+    SecretsUninitialized,
 }
 
 impl ReconcilerError for Error {
@@ -162,14 +162,14 @@ async fn reconcile(sts: Arc<StatefulSet>, ctx: Context<Ctx>) -> Result<Action, E
         .cms_inited
         .load(std::sync::atomic::Ordering::SeqCst)
     {
-        return ConfigMapsUninitedSnafu.fail();
+        return ConfigMapsUninitializedSnafu.fail();
     }
     if !ctx
         .get_ref()
         .secrets_inited
         .load(std::sync::atomic::Ordering::SeqCst)
     {
-        return SecretsUninitedSnafu.fail();
+        return SecretsUninitializedSnafu.fail();
     }
 
     let ns = sts.metadata.namespace.as_deref().unwrap();

--- a/rust/operator-binary/src/restart_controller.rs
+++ b/rust/operator-binary/src/restart_controller.rs
@@ -107,10 +107,10 @@ pub async fn start(client: &Client) -> anyhow::Result<()> {
             ),
         ),
     )
-        .for_each(|res| async move {
-            report_controller_reconciled(client, "commons.superset.stackable.tech", &res)
-        })
-        .await;
+    .for_each(|res| async move {
+        report_controller_reconciled(client, "commons.superset.stackable.tech", &res)
+    })
+    .await;
 
     Ok(())
 }
@@ -119,9 +119,9 @@ fn trigger_all<S, K>(
     stream: S,
     store: Store<K>,
 ) -> impl Stream<Item = Result<ReconcileRequest<K>, S::Error>>
-    where
-        S: TryStream,
-        K: Resource<DynamicType = ()> + Clone,
+where
+    S: TryStream,
+    K: Resource<DynamicType = ()> + Clone,
 {
     trigger_with(stream, move |_| {
         store

--- a/rust/operator-binary/src/restart_controller.rs
+++ b/rust/operator-binary/src/restart_controller.rs
@@ -52,6 +52,15 @@ impl ReconcilerError for Error {
     fn category(&self) -> &'static str {
         ErrorDiscriminants::from(self).into()
     }
+
+    fn secondary_object(&self) -> Option<ObjectRef<DynamicObject>> {
+        match self {
+            Error::ObjectHasNoNamespace { obj_ref } => Some(obj_ref.clone().erase()),
+            Error::Apply { obj_ref, .. } => Some(obj_ref.clone().erase()),
+            Error::ConfigMapsUninitialized => None,
+            Error::SecretsUninitialized => None,
+        }
+    }
 }
 
 pub async fn start(client: &Client) -> anyhow::Result<()> {

--- a/rust/operator-binary/src/restart_controller.rs
+++ b/rust/operator-binary/src/restart_controller.rs
@@ -1,0 +1,308 @@
+use std::collections::BTreeMap;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::{stream, Stream, StreamExt, TryStream};
+use serde_json::json;
+use snafu::Snafu;
+use stackable_operator::client::Client;
+use stackable_operator::k8s_openapi::api::apps::v1::StatefulSet;
+use stackable_operator::k8s_openapi::api::core::v1::{
+    ConfigMap, EnvFromSource, EnvVar, PodSpec, Secret, Volume,
+};
+use stackable_operator::kube;
+use stackable_operator::kube::api::{ListParams, Patch, PatchParams};
+use stackable_operator::kube::core::DynamicObject;
+use stackable_operator::kube::runtime::controller::{
+    trigger_self, trigger_with, Action, Context, ReconcileRequest,
+};
+use stackable_operator::kube::runtime::reflector::{ObjectRef, Store};
+use stackable_operator::kube::runtime::utils::{try_flatten_applied, try_flatten_touched};
+use stackable_operator::kube::runtime::{applier, reflector, watcher};
+use stackable_operator::kube::{Resource, ResourceExt};
+use stackable_operator::logging::controller::{report_controller_reconciled, ReconcilerError};
+use strum::{EnumDiscriminants, IntoStaticStr};
+
+struct Ctx {
+    kube: kube::Client,
+    cms: Store<ConfigMap>,
+    cms_inited: Arc<AtomicBool>,
+    secrets: Store<Secret>,
+    secrets_inited: Arc<AtomicBool>,
+}
+
+#[derive(Snafu, Debug, EnumDiscriminants)]
+#[strum_discriminants(derive(IntoStaticStr))]
+enum Error {
+    #[snafu(display("tried to reconcile {} which has no namespace", obj_ref))]
+    ObjectHasNoNamespace { obj_ref: ObjectRef<DynamicObject> },
+    #[snafu(display("failed to apply update to {}", obj_ref))]
+    Apply {
+        source: kube::Error,
+        obj_ref: ObjectRef<DynamicObject>,
+    },
+    #[snafu(display("configmaps were not yet loaded"))]
+    ConfigMapsUninited,
+    #[snafu(display("secrets were not yet loaded"))]
+    SecretsUninited,
+}
+
+impl ReconcilerError for Error {
+    fn category(&self) -> &'static str {
+        ErrorDiscriminants::from(self).into()
+    }
+}
+
+pub async fn start(client: &Client) -> anyhow::Result<()> {
+    let kube = kube::Client::try_default().await?;
+    let stses = kube::Api::<StatefulSet>::all(kube.clone());
+    let cms = kube::Api::<ConfigMap>::all(kube.clone());
+    let secrets = kube::Api::<Secret>::all(kube.clone());
+    let sts_store = reflector::store::Writer::new(());
+    let cm_store = reflector::store::Writer::new(());
+    let secret_store = reflector::store::Writer::new(());
+    let cms_inited = Arc::new(AtomicBool::from(false));
+    let secrets_inited = Arc::new(AtomicBool::from(false));
+
+    applier(
+        |sts, ctx| Box::pin(reconcile(sts, ctx)),
+        error_policy,
+        Context::new(Ctx {
+            kube,
+            cms: cm_store.as_reader(),
+            secrets: secret_store.as_reader(),
+            cms_inited: cms_inited.clone(),
+            secrets_inited: secrets_inited.clone(),
+        }),
+        sts_store.as_reader(),
+        stream::select(
+            stream::select(
+                trigger_all(
+                    try_flatten_touched(
+                        reflector(cm_store, watcher(cms, ListParams::default())).inspect(|_| {
+                            cms_inited.store(true, std::sync::atomic::Ordering::SeqCst)
+                        }),
+                    ),
+                    sts_store.as_reader(),
+                ),
+                trigger_all(
+                    try_flatten_touched(
+                        reflector(secret_store, watcher(secrets, ListParams::default())).inspect(
+                            |_| secrets_inited.store(true, std::sync::atomic::Ordering::SeqCst),
+                        ),
+                    ),
+                    sts_store.as_reader(),
+                ),
+            ),
+            trigger_self(
+                try_flatten_applied(reflector(
+                    sts_store,
+                    watcher(
+                        stses,
+                        ListParams::default().labels("restarter.stackable.tech/enabled=true"),
+                    ),
+                )),
+                (),
+            ),
+        ),
+    )
+        .for_each(|res| async move {
+            report_controller_reconciled(client, "commons.superset.stackable.tech", &res)
+        })
+        .await;
+
+    Ok(())
+}
+
+fn trigger_all<S, K>(
+    stream: S,
+    store: Store<K>,
+) -> impl Stream<Item = Result<ReconcileRequest<K>, S::Error>>
+    where
+        S: TryStream,
+        K: Resource<DynamicType = ()> + Clone,
+{
+    trigger_with(stream, move |_| {
+        store
+            .state()
+            .into_iter()
+            .map(|obj| ObjectRef::from_obj(obj.as_ref()))
+    })
+}
+
+fn find_pod_refs<'a, K: Resource + 'a>(
+    pod_spec: &'a PodSpec,
+    volume_ref: impl Fn(&Volume) -> Option<ObjectRef<K>> + 'a,
+    env_var_ref: impl Fn(&EnvVar) -> Option<ObjectRef<K>> + 'a,
+    env_from_ref: impl Fn(&EnvFromSource) -> Option<ObjectRef<K>> + 'a,
+) -> impl Iterator<Item = ObjectRef<K>> + 'a {
+    let volume_refs = pod_spec.volumes.iter().flatten().flat_map(volume_ref);
+    let pod_containers = pod_spec
+        .containers
+        .iter()
+        .chain(pod_spec.init_containers.iter().flatten());
+    let container_env_var_refs = pod_containers
+        .clone()
+        .flat_map(|container| &container.env)
+        .flatten()
+        .flat_map(env_var_ref);
+    let container_env_from_refs = pod_containers
+        .flat_map(|container| &container.env_from)
+        .flatten()
+        .flat_map(env_from_ref);
+    volume_refs
+        .chain(container_env_var_refs)
+        .chain(container_env_from_refs)
+}
+
+async fn reconcile(sts: Arc<StatefulSet>, ctx: Context<Ctx>) -> Result<Action, Error> {
+    if !ctx
+        .get_ref()
+        .cms_inited
+        .load(std::sync::atomic::Ordering::SeqCst)
+    {
+        return ConfigMapsUninitedSnafu.fail();
+    }
+    if !ctx
+        .get_ref()
+        .secrets_inited
+        .load(std::sync::atomic::Ordering::SeqCst)
+    {
+        return SecretsUninitedSnafu.fail();
+    }
+
+    let ns = sts.metadata.namespace.as_deref().unwrap();
+    let mut annotations = BTreeMap::<String, String>::new();
+    let pod_specs = sts
+        .spec
+        .iter()
+        .flat_map(|sts_spec| sts_spec.template.spec.as_ref());
+    let cm_refs = pod_specs
+        .clone()
+        .flat_map(|pod_spec| {
+            find_pod_refs(
+                pod_spec,
+                |volume| {
+                    Some(ObjectRef::<ConfigMap>::new(
+                        volume.config_map.as_ref()?.name.as_deref()?,
+                    ))
+                },
+                |env_var| {
+                    Some(ObjectRef::<ConfigMap>::new(
+                        env_var
+                            .value_from
+                            .as_ref()?
+                            .config_map_key_ref
+                            .as_ref()?
+                            .name
+                            .as_deref()?,
+                    ))
+                },
+                |env_from| {
+                    Some(ObjectRef::<ConfigMap>::new(
+                        env_from.config_map_ref.as_ref()?.name.as_deref()?,
+                    ))
+                },
+            )
+        })
+        .map(|cm_ref| cm_ref.within(ns));
+    annotations.extend(
+        cm_refs
+            .flat_map(|cm_ref| ctx.get_ref().cms.get(&cm_ref))
+            .flat_map(|cm| {
+                Some((
+                    format!(
+                        "configmap.restarter.stackable.tech/{}",
+                        cm.metadata.name.as_ref()?
+                    ),
+                    format!(
+                        "{}/{}",
+                        cm.metadata.uid.as_ref()?,
+                        cm.metadata.resource_version.as_ref()?
+                    ),
+                ))
+            }),
+    );
+    let secret_refs = pod_specs
+        .flat_map(|pod_spec| {
+            find_pod_refs(
+                pod_spec,
+                |volume| {
+                    Some(ObjectRef::<Secret>::new(
+                        volume.secret.as_ref()?.secret_name.as_deref()?,
+                    ))
+                },
+                |env_var| {
+                    Some(ObjectRef::<Secret>::new(
+                        env_var
+                            .value_from
+                            .as_ref()?
+                            .secret_key_ref
+                            .as_ref()?
+                            .name
+                            .as_deref()?,
+                    ))
+                },
+                |env_from| {
+                    Some(ObjectRef::<Secret>::new(
+                        env_from.secret_ref.as_ref()?.name.as_deref()?,
+                    ))
+                },
+            )
+        })
+        .map(|secret_ref| secret_ref.within(ns));
+    annotations.extend(
+        secret_refs
+            .flat_map(|secret_ref| ctx.get_ref().secrets.get(&secret_ref))
+            .flat_map(|cm| {
+                Some((
+                    format!(
+                        "secret.restarter.stackable.tech/{}",
+                        cm.metadata.name.as_ref()?
+                    ),
+                    format!(
+                        "{}/{}",
+                        cm.metadata.uid.as_ref()?,
+                        cm.metadata.resource_version.as_ref()?
+                    ),
+                ))
+            }),
+    );
+    let stses = kube::Api::<StatefulSet>::namespaced(ctx.get_ref().kube.clone(), ns);
+    stses
+        .patch(
+            &sts.name(),
+            &PatchParams {
+                force: true,
+                field_manager: Some("restarter.stackable.tech/statefulset".to_string()),
+                ..PatchParams::default()
+            },
+            &Patch::Apply(
+                // Can't use typed API, see https://github.com/Arnavion/k8s-openapi/issues/112
+                json!({
+                    "apiVersion": "apps/v1",
+                    "kind": "StatefulSet",
+                    "metadata": {
+                        "name": sts.metadata.name,
+                        "namespace": sts.metadata.namespace,
+                        "uid": sts.metadata.uid,
+                    },
+                    "spec": {
+                        "template": {
+                            "metadata": {
+                                "annotations": annotations,
+                            },
+                        },
+                    },
+                }),
+            ),
+        )
+        .await
+        .unwrap();
+    Ok(Action::await_change())
+}
+
+fn error_policy(_error: &Error, _ctx: Context<Ctx>) -> Action {
+    Action::requeue(Duration::from_secs(5))
+}


### PR DESCRIPTION
## Description
For https://github.com/stackabletech/issues/issues/200
Actual implementation copied from https://github.com/stackabletech/restart-controller
Integration-Test: https://github.com/stackabletech/integration-tests/pull/207

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
