### PR TITLE
[Merged by Bors] - Revert to also triggering when cms/secrets are deleted

### DIFF
--- a/rust/operator-binary/src/restart_controller/statefulset.rs
+++ b/rust/operator-binary/src/restart_controller/statefulset.rs
@@ -86,7 +86,7 @@ pub async fn start(client: &Client) {
                 trigger_all(
                     reflector(cm_store, watcher(cms, ListParams::default()))
                         .inspect(|_| cms_inited.store(true, std::sync::atomic::Ordering::SeqCst))
-                        .applied_objects(),
+                        .touched_objects(),
                     sts_store.as_reader(),
                 ),
                 trigger_all(
@@ -94,7 +94,7 @@ pub async fn start(client: &Client) {
                         .inspect(|_| {
                             secrets_inited.store(true, std::sync::atomic::Ordering::SeqCst)
                         })
-                        .applied_objects(),
+                        .touched_objects(),
                     sts_store.as_reader(),
                 ),
             ),


### PR DESCRIPTION
# Description

The equivalent for `try_flatten_touched` is `WatchStreamExt::touched_objects`, `WatchStreamExt::applied_objects` corresponds to `try_flatten_applied`.

No changelog entry for this since it's just fixing a regression introduced by #116.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [x] Code contains useful comments
- [x] CRD change approved (or not applicable)
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
