### PR TITLE
cargo chef POC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ render-readme:
 
 ## Docker related targets
 docker-build:
-	docker build --force-rm --build-arg VERSION=${VERSION} -t "docker.stackable.tech/stackable/commons-operator:${VERSION}" -f docker/Dockerfile .
+	docker build --build-arg VERSION=${VERSION} -t "docker.stackable.tech/stackable/commons-operator:${VERSION}" -f docker/Dockerfile.alternative .
 
 docker-build-latest: docker-build
 	docker tag "docker.stackable.tech/stackable/commons-operator:${VERSION}" \

--- a/docker/Dockerfile.alternative
+++ b/docker/Dockerfile.alternative
@@ -22,10 +22,8 @@ WORKDIR /
 # IMPORTANT
 # If you change the toolchain version here, make sure to also change the "rust_version"
 # property in operator-templating/repositories.yaml
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.63.0 \
  && . $HOME/.cargo/env \
- && rustup toolchain install 1.63.0 \
- && rustup default 1.63.0 \
  && cargo install cargo-chef --locked
 
 WORKDIR /src

--- a/docker/Dockerfile.alternative
+++ b/docker/Dockerfile.alternative
@@ -1,0 +1,94 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6@sha256:c5ffdf5938d73283cec018f2adf59f0ed9f8c376d93e415a27b16c3c6aad6f45 AS chef
+LABEL maintainer="Stackable GmbH"
+
+# https://github.com/hadolint/hadolint/wiki/DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Update image and install everything needed for Rustup & Rust
+RUN microdnf update --disablerepo=* --enablerepo=ubi-8-appstream-rpms --enablerepo=ubi-8-baseos-rpms -y \
+  && rm -rf /var/cache/yum \
+  && microdnf install --disablerepo=* --enablerepo=ubi-8-appstream-rpms --enablerepo=ubi-8-baseos-rpms curl findutils gcc gcc-c++ make cmake openssl-devel pkg-config systemd-devel unzip -y \
+  && rm -rf /var/cache/yum
+
+WORKDIR /opt/protoc
+RUN PROTOC_VERSION=21.5 \
+  ARCH=$(arch | sed 's/^aarch64$/aarch_64/') \
+  && curl --location --output protoc.zip "https://repo.stackable.tech/repository/packages/protoc/protoc-${PROTOC_VERSION}-linux-${ARCH}.zip" \
+  && unzip protoc.zip \
+  && rm protoc.zip
+ENV PROTOC=/opt/protoc/bin/protoc
+WORKDIR /
+
+# IMPORTANT
+# If you change the toolchain version here, make sure to also change the "rust_version"
+# property in operator-templating/repositories.yaml
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+ && . $HOME/.cargo/env \
+ && rustup toolchain install 1.63.0 \
+ && rustup default 1.63.0 \
+ && cargo install cargo-chef --locked
+
+WORKDIR /src
+
+FROM chef AS planner
+
+COPY . .
+RUN . $HOME/.cargo/env && cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder 
+
+COPY --from=planner /src/recipe.json recipe.json
+
+# Build dependencies - this is the caching Docker layer!
+RUN . $HOME/.cargo/env && cargo chef cook --release --recipe-path recipe.json
+
+# Build application
+COPY . .
+RUN . $HOME/.cargo/env && cargo build --release
+
+WORKDIR /app
+
+# Copy the "interesting" files into /app.
+RUN find /src/target/release \
+                -regextype egrep \
+                # The interesting binaries are all directly in ${BUILD_DIR}.
+                -maxdepth 1 \
+                # Well, binaries are executable.
+                -executable \
+                # Well, binaries are files.
+                -type f \
+                # Filter out tests.
+                ! -regex ".*\-[a-fA-F0-9]{16,16}$" \
+                # Copy the matching files into /app.
+                -exec cp {} /app \;
+
+RUN echo "The following files will be copied to the runtime image: $(ls /app)"
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal AS operator
+
+ARG VERSION
+ARG RELEASE="1"
+
+LABEL name="Stackable Operator for Stackable Commons" \
+  maintainer="info@stackable.de" \
+  vendor="Stackable GmbH" \
+  version="${VERSION}" \
+  release="${RELEASE}" \
+  summary="Deploy and manage Stackable Commons clusters." \
+  description="Deploy and manage Stackable Commons clusters."
+
+RUN microdnf install -y yum \
+  && yum -y update-minimal --security --sec-severity=Important --sec-severity=Critical \
+  && yum clean all \
+  && microdnf clean all
+
+COPY LICENSE /licenses/LICENSE
+
+COPY --from=builder /app/stackable-commons-operator /
+
+RUN groupadd -g 1000 stackable && adduser -u 1000 -g stackable -c 'Stackable Operator' stackable
+
+USER stackable:stackable
+
+ENTRYPOINT ["/stackable-commons-operator"]
+CMD ["run"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.65.0"
+channel = "1.63.0"

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -24,6 +24,7 @@ struct Opts {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    //println!("TODO: remove me!");
     let opts = Opts::parse();
     match opts.cmd {
         Command::Crd => {


### PR DESCRIPTION
This PR demonstrates how to use [`cargo chef`](https://github.com/LukeMathWalker/cargo-chef) to speed up Rust builds in Docker. For this purpose, a self-contained Docker file has been created called `docker/Docker.alternative`

The idea is to cache Rust dependencies in a Docker layer before actually building the project. A preliminary step called `cargo chef cook` achieves this by building a mock version of the project with all it's dependencies.

The actual project build reuses the dependencies from the previous layer and compiles just the project source code. 

Tested with:

```
make docker-build && docker run docker.stackable.tech/stackable/commons-operator:0.5.0-nightly crd
```
