### PR TITLE
[Merged by Bors] - BUGFIX: Revert openshift-specific settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Specified security context settings needed for OpenShift ([#136]).
+- Revert openshift settings ([#xxx])
 
 [#136]: https://github.com/stackabletech/commons-operator/pull/136
+[#xxx]: https://github.com/stackabletech/commons-operator/pull/xxx
 
 ## [23.1.0] - 2023-01-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Specified security context settings needed for OpenShift ([#136]).
-- Revert openshift settings ([#xxx])
+- Revert openshift settings ([#142])
 
 [#136]: https://github.com/stackabletech/commons-operator/pull/136
-[#xxx]: https://github.com/stackabletech/commons-operator/pull/xxx
+[#142]: https://github.com/stackabletech/commons-operator/pull/142
 
 ## [23.1.0] - 2023-01-23
 

--- a/deploy/helm/commons-operator/values.yaml
+++ b/deploy/helm/commons-operator/values.yaml
@@ -22,18 +22,7 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext:
-  capabilities:
-    drop:
-    - ALL
-  allowPrivilegeEscalation: false
-  seccompProfile:
-    type: RuntimeDefault
-  # readOnlyRootFilesystem: true
-  # openshift requires a UID if one is not given in the image definition (e.g. "stackable")
-  # to verify that the user is non-root
-  runAsNonRoot: true
-  runAsUser: 1000
+securityContext: {}
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
# Description

Openshift-specific settings are no longer needed as operators will be packaged with olm for OS clusters.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
