### PR TITLE
fix: Respect `--watch-namespace` CLI argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Respect `--watch-namespace` CLI argument ([#193]).
+
+[#193]: https://github.com/stackabletech/commons-operator/pull/193
+
 ## [23.11.0] - 2023-11-24
 
 ## [23.7.0] - 2023-07-14

--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> anyhow::Result<()> {
         }
         Command::Run(ProductOperatorRun {
             product_config: _,
-            watch_namespace: _,
+            watch_namespace,
             tracing_target,
         }) => {
             stackable_operator::logging::initialize_logging(
@@ -58,9 +58,11 @@ async fn main() -> anyhow::Result<()> {
             ))
             .await?;
 
-            let sts_restart_controller = restart_controller::statefulset::start(&client);
-            let pod_restart_controller = restart_controller::pod::start(&client);
-            let pod_enrichment_controller = pod_enrichment_controller::start(&client);
+            let sts_restart_controller =
+                restart_controller::statefulset::start(&client, &watch_namespace);
+            let pod_restart_controller = restart_controller::pod::start(&client, &watch_namespace);
+            let pod_enrichment_controller =
+                pod_enrichment_controller::start(&client, &watch_namespace);
             pin_mut!(
                 sts_restart_controller,
                 pod_restart_controller,

--- a/rust/operator-binary/src/pod_enrichment_controller.rs
+++ b/rust/operator-binary/src/pod_enrichment_controller.rs
@@ -9,6 +9,7 @@ use stackable_operator::{
         runtime::{controller, reflector::ObjectRef, watcher, Controller},
     },
     logging::controller::{report_controller_reconciled, ReconcilerError},
+    namespace::WatchNamespace,
 };
 use strum::{EnumDiscriminants, IntoStaticStr};
 
@@ -46,9 +47,9 @@ impl ReconcilerError for Error {
     }
 }
 
-pub async fn start(client: &stackable_operator::client::Client) {
+pub async fn start(client: &stackable_operator::client::Client, watch_namespace: &WatchNamespace) {
     let controller = Controller::new(
-        client.get_all_api::<Pod>(),
+        watch_namespace.get_api::<Pod>(client),
         watcher::Config::default().labels("enrichment.stackable.tech/enabled=true"),
     );
     let pods = controller.store();

--- a/rust/operator-binary/src/restart_controller/pod.rs
+++ b/rust/operator-binary/src/restart_controller/pod.rs
@@ -15,6 +15,7 @@ use stackable_operator::{
         runtime::{controller::Action, reflector::ObjectRef, watcher, Controller},
     },
     logging::controller::{report_controller_reconciled, ReconcilerError},
+    namespace::WatchNamespace,
 };
 use strum::{EnumDiscriminants, IntoStaticStr};
 
@@ -60,8 +61,11 @@ impl ReconcilerError for Error {
     }
 }
 
-pub async fn start(client: &Client) {
-    let controller = Controller::new(client.get_all_api::<Pod>(), watcher::Config::default());
+pub async fn start(client: &Client, watch_namespace: &WatchNamespace) {
+    let controller = Controller::new(
+        watch_namespace.get_api::<Pod>(client),
+        watcher::Config::default(),
+    );
     controller
         .run(
             reconcile,


### PR DESCRIPTION
# Description

Currently we ignore the CLI argument.
I think this is especially important for commons-op, as it consumes the most memory of all our operators.
If we don't merge this for any reasons we should remove the `--watch-namespace` CLI argument.


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
