### PR TITLE
chore: upgrade operator-rs to 0.60.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "delegate"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e018fccbeeb50ff26562ece792ed06659b9c2dae79ece77c4456bb10d9bf79b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1881,12 +1892,13 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.58.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.58.1#ab309d577e1937834f2adcbcd647822aa9c2ae43"
+version = "0.60.1"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.60.1#21f98e8937dac924e374b54bd6ea1d7b2367ca69"
 dependencies = [
  "chrono",
  "clap",
  "const_format",
+ "delegate",
  "derivative",
  "dockerfile-parser",
  "either",
@@ -1919,8 +1931,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator-derive"
-version = "0.58.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.58.1#ab309d577e1937834f2adcbcd647822aa9c2ae43"
+version = "0.60.1"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.60.1#21f98e8937dac924e374b54bd6ea1d7b2367ca69"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = ["rust/operator-binary"]
 
 [workspace.package]
@@ -10,13 +11,13 @@ repository = "https://github.com/stackabletech/commons-operator"
 
 [workspace.dependencies]
 anyhow = "1.0"
-built = { version =  "0.6", features = ["chrono", "git2"] }
+built = { version = "0.6", features = ["chrono", "git2"] }
 clap = "4.3"
 futures = { version = "0.3", features = ["compat"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snafu = "0.7"
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.58.1" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.60.1" }
 strum = { version = "0.25", features = ["derive"] }
 tokio = { version = "1.29", features = ["full"] }
 tracing = "0.1"


### PR DESCRIPTION
# Description

Bump operator-rs, no code changes needed.
- The commons operator doesn't set labels

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
