### PR TITLE
Fix links

### DIFF
--- a/.readme/partials/main.md.j2
+++ b/.readme/partials/main.md.j2
@@ -9,7 +9,7 @@ Once installed it should run unattended and do [its thing](https://docs.stackabl
 
 ## Installation
 
-You can install the operator using [stackablectl or helm](https://docs.stackable.tech/home/stable/commons-operator/getting_started/installation).
+You can install the operator using [stackablectl or helm](https://docs.stackable.tech/home/stable/{{operator_docs_slug}}/getting_started/installation).
 
 {% filter trim %}
   {%- include "partials/borrowed/documentation.md.j2" -%}

--- a/.readme/partials/main.md.j2
+++ b/.readme/partials/main.md.j2
@@ -1,7 +1,7 @@
 Operator for common objects of the Stackable Data Platform (SDP).
 This operator is required for most installations of the SDP and some things might not work if you do not install it.
 
-Once installed it should run unattended and do [its thing](https://docs.stackable.tech/home/stable/{{operator_name}}/usage).
+Once installed it should run unattended and do [its thing](https://docs.stackable.tech/home/stable/commons-operator/usage).
 
 {% filter trim %}
   {%- include "partials/borrowed/overview_blurb.md.j2" -%}
@@ -9,7 +9,7 @@ Once installed it should run unattended and do [its thing](https://docs.stackabl
 
 ## Installation
 
-You can install the operator using [stackablectl or helm](https://docs.stackable.tech/home/stable/{{operator_name}}/getting_started/installation).
+You can install the operator using [stackablectl or helm](https://docs.stackable.tech/home/stable/commons-operator/getting_started/installation).
 
 {% filter trim %}
   {%- include "partials/borrowed/documentation.md.j2" -%}

--- a/.readme/partials/main.md.j2
+++ b/.readme/partials/main.md.j2
@@ -1,7 +1,7 @@
 Operator for common objects of the Stackable Data Platform (SDP).
 This operator is required for most installations of the SDP and some things might not work if you do not install it.
 
-Once installed it should run unattended and do [its thing](https://docs.stackable.tech/home/stable/commons-operator/usage).
+Once installed it should run unattended and do [its thing](https://docs.stackable.tech/home/stable/{{operator_docs_slug}}/usage).
 
 {% filter trim %}
   {%- include "partials/borrowed/overview_blurb.md.j2" -%}

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@
 Operator for common objects of the Stackable Data Platform (SDP).
 This operator is required for most installations of the SDP and some things might not work if you do not install it.
 
-Once installed it should run unattended and do [its thing](https://docs.stackable.tech/home/stable/commons/usage).
+Once installed it should run unattended and do [its thing](https://docs.stackable.tech/home/stable/commons-operator/usage).
 
 It is part of the Stackable Data Platform, a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino or Apache Spark, [all](#other-operators) working together seamlessly. Based on Kubernetes, it runs everywhere – [on prem or in the cloud](#supported-platforms).
 
 ## Installation
 
-You can install the operator using [stackablectl or helm](https://docs.stackable.tech/home/stable/commons/getting_started/installation).
+You can install the operator using [stackablectl or helm](https://docs.stackable.tech/home/stable/commons-operator/getting_started/installation).
 
 ## Documentation
 


### PR DESCRIPTION
For some reason commons, listener and secret operator have different URL structures from the others.