### PR TITLE
docs: remove home module from refs (stackabletech/documentation#637) / 23.1

### DIFF
--- a/docs/modules/commons-operator/pages/authenticationclass.adoc
+++ b/docs/modules/commons-operator/pages/authenticationclass.adoc
@@ -1,3 +1,3 @@
 = AuthenticationClass
 
-Moved to xref:23.1@home:concepts:authentication.adoc[]
+Moved to xref:23.1@concepts:authentication.adoc[]


### PR DESCRIPTION
# Description

docs: remove home module from refs (stackabletech/documentation#637) / 23.1