### PR TITLE
chore: Update to operator-rs 0.78.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Bump `stackable-operator` to 0.70.0, and other dependencies ([#267]).
+- BREAKING: Bump `stackable-operator` to 0.78.0 which includes a new `AuthenticationClassProvider` member for Kerberos. This will need to be considered when validating authentication providers ([#285]).
 
 [#267]: https://github.com/stackabletech/commons-operator/pull/267
+[#285]: https://github.com/stackabletech/commons-operator/pull/285
 
 ## [24.3.0] - 2024-03-20
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2088,8 +2088,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.76.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.76.0#a7e70f174fb043a1766e0a80de95834cb4f7513d"
+version = "0.78.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.78.0#8b0172ded942499845ebf647ef1b17ccfc7bdbb3"
 dependencies = [
  "chrono",
  "clap",
@@ -2099,6 +2099,7 @@ dependencies = [
  "dockerfile-parser",
  "either",
  "futures 0.3.30",
+ "indexmap",
  "json-patch",
  "k8s-openapi",
  "kube",
@@ -2125,7 +2126,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator-derive"
 version = "0.3.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.76.0#a7e70f174fb043a1766e0a80de95834cb4f7513d"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.78.0#8b0172ded942499845ebf647ef1b17ccfc7bdbb3"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -6483,13 +6483,13 @@ rec {
       };
       "stackable-operator" = rec {
         crateName = "stackable-operator";
-        version = "0.76.0";
+        version = "0.78.0";
         edition = "2021";
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "a7e70f174fb043a1766e0a80de95834cb4f7513d";
-          sha256 = "1cyyyn6lizd0wdq79fc9fjnksnzx073ipydxmh7llciq5si5dnq6";
+          rev = "8b0172ded942499845ebf647ef1b17ccfc7bdbb3";
+          sha256 = "0nd05xk84s4jdd635ivvwp0lxqghxdxz45cf40xyx07k9bqq4fzg";
         };
         libName = "stackable_operator";
         authors = [
@@ -6529,6 +6529,10 @@ rec {
           {
             name = "futures";
             packageId = "futures 0.3.30";
+          }
+          {
+            name = "indexmap";
+            packageId = "indexmap";
           }
           {
             name = "json-patch";
@@ -6638,8 +6642,8 @@ rec {
         workspace_member = null;
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
-          rev = "a7e70f174fb043a1766e0a80de95834cb4f7513d";
-          sha256 = "1cyyyn6lizd0wdq79fc9fjnksnzx073ipydxmh7llciq5si5dnq6";
+          rev = "8b0172ded942499845ebf647ef1b17ccfc7bdbb3";
+          sha256 = "0nd05xk84s4jdd635ivvwp0lxqghxdxz45cf40xyx07k9bqq4fzg";
         };
         procMacro = true;
         libName = "stackable_operator_derive";

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ futures = { version = "0.3", features = ["compat"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snafu = "0.8"
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.76.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "stackable-operator-0.78.0" }
 strum = { version = "0.26", features = ["derive"] }
 tokio = { version = "1.40", features = ["full"] }
 tracing = "0.1"

--- a/crate-hashes.json
+++ b/crate-hashes.json
@@ -1,5 +1,5 @@
 {
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.76.0#stackable-operator-derive@0.3.1": "1cyyyn6lizd0wdq79fc9fjnksnzx073ipydxmh7llciq5si5dnq6",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.76.0#stackable-operator@0.76.0": "1cyyyn6lizd0wdq79fc9fjnksnzx073ipydxmh7llciq5si5dnq6",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.78.0#stackable-operator-derive@0.3.1": "0nd05xk84s4jdd635ivvwp0lxqghxdxz45cf40xyx07k9bqq4fzg",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.78.0#stackable-operator@0.78.0": "0nd05xk84s4jdd635ivvwp0lxqghxdxz45cf40xyx07k9bqq4fzg",
   "git+https://github.com/stackabletech/product-config.git?tag=0.7.0#product-config@0.7.0": "0gjsm80g6r75pm3824dcyiz4ysq1ka4c1if6k1mjm9cnd5ym0gny"
 }

--- a/deploy/helm/commons-operator/crds/crds.yaml
+++ b/deploy/helm/commons-operator/crds/crds.yaml
@@ -35,7 +35,18 @@ spec:
                         - oidc
                     - required:
                         - tls
+                    - required:
+                        - kerberos
                   properties:
+                    kerberos:
+                      description: The [Kerberos provider](https://docs.stackable.tech/home/nightly/concepts/authentication#_kerberos). The Kerberos AuthenticationClass is used when users should authenticate themselves via Kerberos.
+                      properties:
+                        kerberosSecretClass:
+                          description: Mandatory SecretClass used to obtain keytabs.
+                          type: string
+                      required:
+                        - kerberosSecretClass
+                      type: object
                     ldap:
                       description: The [LDAP provider](https://docs.stackable.tech/home/nightly/concepts/authentication#_ldap). There is also the ["Authentication with LDAP" tutorial](https://docs.stackable.tech/home/nightly/tutorials/authentication_with_openldap) where you can learn to configure Superset and Trino with OpenLDAP.
                       properties:


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/kafka-operator/pull/762.

- BREAKING: This is a breaking change as `match` statements that check for values of `pub enum AuthenticationClassProvider` will need to consider the new case i.e. if operators are checking for each discrete enum member, the addition of the new one will result in a missing arm in the match statement, and if they are not (instead using a wildcard `_`), then the new member will be undetected.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [x] CRD changes approved
- [x] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
