### PR TITLE
Adds missing KUBERNETES_CLUSTER_DOMAIN environment variable to docs

### DIFF
--- a/docs/modules/commons-operator/pages/reference/environment-variables.adoc
+++ b/docs/modules/commons-operator/pages/reference/environment-variables.adoc
@@ -1,0 +1,34 @@
+= Environment variables
+
+This operator accepts the following environment variables:
+
+== KUBERNETES_CLUSTER_DOMAIN
+
+*Default value*: cluster.local
+
+*Required*: false
+
+*Multiple values*: false
+
+This instructs the operator, which value it should use for the Kubernetes `clusterDomain` setting.
+Make sure to keep this in sync with whatever setting your cluster uses.
+Please see the documentation xref:guides:kubernetes-cluster-domain.adoc[on configuring the Kubernetes cluster domain] for more information on this feature.
+
+[source]
+----
+export KUBERNETES_CLUSTER_DOMAIN=mycluster.local
+cargo run -- run
+----
+
+or via docker:
+
+[source]
+----
+docker run \
+--name commons-operator \
+--network host \
+--env KUBECONFIG=/home/stackable/.kube/config \
+--env KUBERNETES_CLUSTER_DOMAIN=mycluster.local \
+--mount type=bind,source="$HOME/.kube/config",target="/home/stackable/.kube/config" \
+docker.stackable.tech/stackable/commons-operator:0.0.0-dev
+----

--- a/docs/modules/commons-operator/pages/reference/environment-variables.adoc
+++ b/docs/modules/commons-operator/pages/reference/environment-variables.adoc
@@ -19,16 +19,3 @@ Please see the documentation xref:guides:kubernetes-cluster-domain.adoc[on confi
 export KUBERNETES_CLUSTER_DOMAIN=mycluster.local
 cargo run -- run
 ----
-
-or via docker:
-
-[source]
-----
-docker run \
---name commons-operator \
---network host \
---env KUBECONFIG=/home/stackable/.kube/config \
---env KUBERNETES_CLUSTER_DOMAIN=mycluster.local \
---mount type=bind,source="$HOME/.kube/config",target="/home/stackable/.kube/config" \
-docker.stackable.tech/stackable/commons-operator:0.0.0-dev
-----

--- a/docs/modules/commons-operator/pages/reference/index.adoc
+++ b/docs/modules/commons-operator/pages/reference/index.adoc
@@ -3,7 +3,8 @@
 Consult the reference documentation section to find exhaustive information on:
 
 * Descriptions and default values of all properties in the CRDs used by this operator in the xref:reference/crds.adoc[].
+* The xref:reference/environment-variables.adoc[] accepted by the operator.
 
-== Command line parameters and environment variables
+== Command line parameters
 
-At the moment this operator accepts no command line parameters and does not read any environment variables.
+At the moment this operator accepts no command line parameters.


### PR DESCRIPTION
# Description

Adds missing KUBERNETES_CLUSTER_DOMAIN environment variable to docs.

part of https://github.com/stackabletech/issues/issues/668