### PR TITLE
chore: Remove unused const

### DIFF
--- a/rust/operator-binary/src/main.rs
+++ b/rust/operator-binary/src/main.rs
@@ -16,9 +16,6 @@ mod built_info {
     include!(concat!(env!("OUT_DIR"), "/built.rs"));
 }
 
-// TODO (@NickLarsenNZ): Change the variable to `CONSOLE_LOG`
-pub const ENV_VAR_CONSOLE_LOG: &str = "COMMONS_OPERATOR_LOG";
-
 #[derive(Parser)]
 #[clap(about, author)]
 struct Opts {


### PR DESCRIPTION
This was missed in https://github.com/stackabletech/commons-operator/pull/344