### PR TITLE
fix: workaround for long certificate lifetimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
     by `FILE_LOG_DIRECTORY` (or via `--file-log-directory <DIRECTORY>`).
   - Replace stackable-operator `print_startup_string` with `tracing::info!` with fields.
 - Version CRDs and bump dependencies ([#353]).
+- Limit rescheduling delay to a maximum of 6 months ([#363]).
 
 ### Fixed
 
@@ -30,6 +31,7 @@ All notable changes to this project will be documented in this file.
 [#344]: https://github.com/stackabletech/commons-operator/pull/344
 [#349]: https://github.com/stackabletech/commons-operator/pull/349
 [#353]: https://github.com/stackabletech/commons-operator/pull/353
+[#363]: https://github.com/stackabletech/commons-operator/pull/363
 
 ## [25.3.0] - 2025-03-21
 

--- a/rust/operator-binary/src/restart_controller/pod.rs
+++ b/rust/operator-binary/src/restart_controller/pod.rs
@@ -174,6 +174,10 @@ async fn reconcile(pod: Arc<PartialObjectMeta<Pod>>, ctx: Arc<Ctx>) -> Result<Ac
         }
 
         Some(Ok(time_until_pod_expires)) => {
+            // Clamp the rescheduling delay to a maximum of 6 months to prevent `Action::requeue` from panicking
+            // This workaround can be removed once https://github.com/kube-rs/kube/issues/1772 is resolved
+            let time_until_pod_expires =
+                time_until_pod_expires.min(Duration::from_secs(6 * 30 * 24 * 60 * 60));
             tracing::info!(
                 pod.expires_at = ?pod_expires_at,
                 recheck_delay = ?time_until_pod_expires,


### PR DESCRIPTION
## Description

Workaround for https://github.com/stackabletech/commons-operator/issues/362

Tested by temporary setting the maximum delay to 1 minute (instead of 6 months) and requesting a cert with a couple minutes lifetime. It rescheduled a few times and then restarted the Pod with a new cert, so the Pod lived for multiple minutes even though the maximum delay was 1 minute, see the `recheck_delay` in these logs:
```
2025-06-24T13:47:21.234336Z  INFO reconciling object{object.ref=Pod.v1./example-secret-consumer-0.default object.reason=reconciler requested retry}: stackable_commons_operator::restart_controller::pod: Pod still valid, rescheduling check pod.expires_at=Some(2025-06-24T13:55:11.594779133+00:00) recheck_delay=60s
2025-06-24T13:48:21.237989Z  INFO reconciling object{object.ref=Pod.v1./example-secret-consumer-0.default object.reason=reconciler requested retry}: stackable_commons_operator::restart_controller::pod: Pod still valid, rescheduling check pod.expires_at=Some(2025-06-24T13:55:11.594779133+00:00) recheck_delay=60s
2025-06-24T13:49:21.240752Z  INFO reconciling object{object.ref=Pod.v1./example-secret-consumer-0.default object.reason=reconciler requested retry}: stackable_commons_operator::restart_controller::pod: Pod still valid, rescheduling check pod.expires_at=Some(2025-06-24T13:55:11.594779133+00:00) recheck_delay=60s
2025-06-24T13:50:21.244534Z  INFO reconciling object{object.ref=Pod.v1./example-secret-consumer-0.default object.reason=reconciler requested retry}: stackable_commons_operator::restart_controller::pod: Pod still valid, rescheduling check pod.expires_at=Some(2025-06-24T13:55:11.594779133+00:00) recheck_delay=60s
2025-06-24T13:51:21.247748Z  INFO reconciling object{object.ref=Pod.v1./example-secret-consumer-0.default object.reason=reconciler requested retry}: stackable_commons_operator::restart_controller::pod: Pod still valid, rescheduling check pod.expires_at=Some(2025-06-24T13:55:11.594779133+00:00) recheck_delay=60s
2025-06-24T13:52:21.250501Z  INFO reconciling object{object.ref=Pod.v1./example-secret-consumer-0.default object.reason=reconciler requested retry}: stackable_commons_operator::restart_controller::pod: Pod still valid, rescheduling check pod.expires_at=Some(2025-06-24T13:55:11.594779133+00:00) recheck_delay=60s
2025-06-24T13:53:21.254136Z  INFO reconciling object{object.ref=Pod.v1./example-secret-consumer-0.default object.reason=reconciler requested retry}: stackable_commons_operator::restart_controller::pod: Pod still valid, rescheduling check pod.expires_at=Some(2025-06-24T13:55:11.594779133+00:00) recheck_delay=60s
2025-06-24T13:54:21.257055Z  INFO reconciling object{object.ref=Pod.v1./example-secret-consumer-0.default object.reason=reconciler requested retry}: stackable_commons_operator::restart_controller::pod: Pod still valid, rescheduling check pod.expires_at=Some(2025-06-24T13:55:11.594779133+00:00) recheck_delay=50.33773894s
```

Which confirms certificate lifetimes greater than the new maximum delay of 6 months still work as expected.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [x] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
