### PR TITLE
chore: Release 25.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [25.7.0] - 2025-07-23
+
 ## [25.7.0-rc1] - 2025-07-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2523,7 +2523,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stackable-commons-operator"
-version = "25.7.0-rc1"
+version = "25.7.0"
 dependencies = [
  "anyhow",
  "built",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -8222,7 +8222,7 @@ rec {
       };
       "stackable-commons-operator" = rec {
         crateName = "stackable-commons-operator";
-        version = "25.7.0-rc1";
+        version = "25.7.0";
         edition = "2021";
         crateBin = [
           {

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["rust/operator-binary"]
 resolver = "2"
 
 [workspace.package]
-version = "25.7.0-rc1"
+version = "25.7.0"
 authors = ["Stackable GmbH <info@stackable.tech>"]
 license = "OSL-3.0"
 edition = "2021"

--- a/deploy/helm/commons-operator/Chart.yaml
+++ b/deploy/helm/commons-operator/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v2
 name: commons-operator
-version: "25.7.0-rc1"
-appVersion: "25.7.0-rc1"
+version: "25.7.0"
+appVersion: "25.7.0"
 description: The Stackable Operator for Stackable Commons
 home: https://github.com/stackabletech/commons-operator
 maintainers:

--- a/tests/release.yaml
+++ b/tests/release.yaml
@@ -7,4 +7,4 @@ releases:
     description: Integration test
     products:
       commons:
-        operatorVersion: 25.7.0-rc1
+        operatorVersion: 25.7.0


### PR DESCRIPTION
> [!CAUTION]
> ## DO NOT MERGE MANUALLY!
> This branch will be merged (and the commit tagged) by stackable-utils once any necessary commits have been cherry-picked to here from the main branch.