### PR TITLE
chore: Reduce severity of Pod eviction errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Reduce severity of Pod eviction errors. Previously, the operator would produce lot's of
+  `Cannot evict pod as it would violate the pod's disruption budget` errors. With this fix, the
+  error is reduced to an info instead ([#372]).
+
+[#372]: https://github.com/stackabletech/commons-operator/pull/372
+
 ## [25.7.0] - 2025-07-23
 
 ## [25.7.0-rc1] - 2025-07-18

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,9 +2453,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2529,6 +2529,7 @@ dependencies = [
  "built",
  "clap",
  "futures 0.3.31",
+ "http",
  "serde",
  "serde_json",
  "snafu 0.8.6",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -8020,9 +8020,9 @@ rec {
       };
       "slab" = rec {
         crateName = "slab";
-        version = "0.4.10";
+        version = "0.4.11";
         edition = "2018";
-        sha256 = "03f5a9gdp33mngya4qwq2555138pj74pl015scv57wsic5rikp04";
+        sha256 = "12bm4s88rblq02jjbi1dw31984w61y2ldn13ifk5gsqgy97f8aks";
         authors = [
           "Carl Lerche <me@carllerche.com>"
         ];

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -8250,6 +8250,10 @@ rec {
             features = [ "compat" ];
           }
           {
+            name = "http";
+            packageId = "http";
+          }
+          {
             name = "serde";
             packageId = "serde";
             features = [ "derive" ];

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0"
 built = { version = "0.8", features = ["chrono", "git2"] }
 clap = "4.5"
 futures = { version = "0.3", features = ["compat"] }
+http = "1.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snafu = "0.8"

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -13,6 +13,7 @@ stackable-operator.workspace = true
 
 anyhow.workspace = true
 clap.workspace = true
+http.workspace = true
 futures.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/rust/operator-binary/src/restart_controller/pod.rs
+++ b/rust/operator-binary/src/restart_controller/pod.rs
@@ -211,7 +211,7 @@ async fn report_result(
         Error::EvictPod {
             source: evict_pod_error,
         },
-        pod,
+        pod_ref,
     )) = &result
     {
         const TOO_MANY_REQUESTS_HTTP_CODE: u16 = StatusCode::TOO_MANY_REQUESTS.as_u16();
@@ -230,7 +230,7 @@ async fn report_result(
         {
             if error_message == EVICT_ERROR_MESSAGE {
                 tracing::info!(
-                    %pod,
+                    k8s.object_ref = %pod_ref,
                     error = %evict_pod_error,
                     "Tried to evict Pod, but wasn't allowed to do so, as it would violate the Pod's disruption budget. Retrying later"
                 );

--- a/rust/operator-binary/src/restart_controller/pod.rs
+++ b/rust/operator-binary/src/restart_controller/pod.rs
@@ -199,6 +199,7 @@ async fn reconcile(pod: Arc<PartialObjectMeta<Pod>>, ctx: Arc<Ctx>) -> Result<Ac
 /// Because of this, we don't emit an error for this case, but only product a INFO trace.
 ///
 /// `ERROR stackable_operator::logging::controller: Failed to reconcile object controller.name="pod.restarter.commons.stackable.tech" error=reconciler for object Pod.v1./trino-worker-default-0.default failed error.sources=[failed to evict Pod, ApiError: Cannot evict pod as it would violate the pod's disruption budget.: TooManyRequests (ErrorResponse { status: "Failure", message: "Cannot evict pod as it would violate the pod's disruption budget.", reason: "TooManyRequests", code: 429 }), Cannot evict pod as it would violate the pod's disruption budget.: TooManyRequests]`
+#[allow(clippy::type_complexity)] // The result type complexity comes from kube-rs and is what it is
 async fn report_result(
     result: Result<
         (ObjectRef<PartialObjectMeta<Pod>>, Action),

--- a/rust/operator-binary/src/restart_controller/pod.rs
+++ b/rust/operator-binary/src/restart_controller/pod.rs
@@ -230,7 +230,7 @@ async fn report_result(
         {
             if error_message == EVICT_ERROR_MESSAGE {
                 tracing::info!(
-                    k8s.object_ref = %pod_ref,
+                    k8s.object.ref = %pod_ref,
                     error = %evict_pod_error,
                     "Tried to evict Pod, but wasn't allowed to do so, as it would violate the Pod's disruption budget. Retrying later"
                 );

--- a/rust/operator-binary/src/restart_controller/pod.rs
+++ b/rust/operator-binary/src/restart_controller/pod.rs
@@ -211,7 +211,7 @@ async fn report_result(
         Error::EvictPod {
             source: evict_pod_error,
         },
-        _,
+        pod,
     )) = &result
     {
         const TOO_MANY_REQUESTS_HTTP_CODE: u16 = StatusCode::TOO_MANY_REQUESTS.as_u16();
@@ -221,9 +221,11 @@ async fn report_result(
         }) = evict_pod_error
         {
             tracing::info!(
-                ?evict_pod_error,
+                %pod,
+                error = %evict_pod_error,
                 "Tried to evict Pod, but wasn't allowed to do so, as it would violate the Pod's disruption budget. Retrying later"
             );
+            return;
         }
     }
 

--- a/rust/operator-binary/src/restart_controller/pod.rs
+++ b/rust/operator-binary/src/restart_controller/pod.rs
@@ -1,6 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
 use futures::StreamExt;
+use http::StatusCode;
 use snafu::{OptionExt, ResultExt, Snafu};
 use stackable_operator::{
     client::Client,
@@ -11,10 +12,10 @@ use stackable_operator::{
     kube::{
         self,
         api::{EvictParams, PartialObjectMeta},
-        core::DynamicObject,
+        core::{DynamicObject, ErrorResponse},
         runtime::{
             Controller,
-            controller::Action,
+            controller::{self, Action},
             events::{Recorder, Reporter},
             reflector::ObjectRef,
             watcher,
@@ -96,10 +97,7 @@ pub async fn start(client: &Client, watch_namespace: &WatchNamespace) {
                 // The event_recorder needs to be shared across all invocations, so that
                 // events are correctly aggregated
                 let event_recorder = event_recorder.clone();
-                async move {
-                    report_controller_reconciled(&event_recorder, FULL_CONTROLLER_NAME, &result)
-                        .await;
-                }
+                async move { report_result(result, event_recorder).await }
             },
         )
         .await;
@@ -190,6 +188,45 @@ async fn reconcile(pod: Arc<PartialObjectMeta<Pod>>, ctx: Arc<Ctx>) -> Result<Ac
             Ok(Action::await_change())
         }
     }
+}
+
+/// Reports the result of reconciliation.
+///
+/// The Pod restart controller has special handling, as it produced lot's of error messages below.
+/// They are expected, as we intentionally use the `Evict` API to restart Pods before e.g. the
+/// certificate expires. We roll out PDBs by default. If we try to restart multiple Pods that are
+/// part of a PDB, we get this errors.
+/// Because of this, we don't emit an error for this case, but only product a INFO trace.
+///
+/// `ERROR stackable_operator::logging::controller: Failed to reconcile object controller.name="pod.restarter.commons.stackable.tech" error=reconciler for object Pod.v1./trino-worker-default-0.default failed error.sources=[failed to evict Pod, ApiError: Cannot evict pod as it would violate the pod's disruption budget.: TooManyRequests (ErrorResponse { status: "Failure", message: "Cannot evict pod as it would violate the pod's disruption budget.", reason: "TooManyRequests", code: 429 }), Cannot evict pod as it would violate the pod's disruption budget.: TooManyRequests]`
+async fn report_result(
+    result: Result<
+        (ObjectRef<PartialObjectMeta<Pod>>, Action),
+        controller::Error<Error, watcher::Error>,
+    >,
+    event_recorder: Arc<Recorder>,
+) {
+    if let Err(controller::Error::ReconcilerFailed(
+        Error::EvictPod {
+            source: evict_pod_error,
+        },
+        _,
+    )) = &result
+    {
+        const TOO_MANY_REQUESTS_HTTP_CODE: u16 = StatusCode::TOO_MANY_REQUESTS.as_u16();
+        if let kube::Error::Api(ErrorResponse {
+            code: TOO_MANY_REQUESTS_HTTP_CODE,
+            ..
+        }) = evict_pod_error
+        {
+            tracing::info!(
+                ?evict_pod_error,
+                "Tried to evict Pod, but wasn't allowed to do so, as it would violate the Pod's disruption budget. Retrying later"
+            );
+        }
+    }
+
+    report_controller_reconciled(&event_recorder, FULL_CONTROLLER_NAME, &result).await;
 }
 
 fn error_policy(_obj: Arc<PartialObjectMeta<Pod>>, _error: &Error, _ctx: Arc<Ctx>) -> Action {


### PR DESCRIPTION
## Description

https://stackable-workspace.slack.com/archives/C08GM6S8Z8D/p1755112180910679

Tested by spinning up an ZookeeperCluster with 21 nodes and setting the expiration annotation of all of them at once to the past.
With this PR no error messages, only INFOs

`
2025-08-19T07:53:19.458655Z  INFO stackable_commons_operator::restart_controller::pod: Tried to evict Pod, but wasn't allowed to do so, as it would violate the Pod's disruption budget. Retrying later pod=Pod.v1./simple-zk-server-default-17.default error=ApiError: Cannot evict pod as it would violate the pod's disruption budget.: TooManyRequests (ErrorResponse { status: "Failure", message: "Cannot evict pod as it would violate the pod's disruption budget.", reason: "TooManyRequests", code: 429 })
`

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
