### PR TITLE
test: Fix the restarter test

### DIFF
--- a/tests/templates/kuttl/restarter/10-assert.yaml
+++ b/tests/templates/kuttl/restarter/10-assert.yaml
@@ -4,7 +4,7 @@ kind: TestAssert
 timeout: 120
 commands:
   - script: |
-      . test-script.sh
+      . ./test-script.sh
 
       # Wait for the StatefulSet to be deployed
       kubectl rollout status statefulset/test --namespace "$NAMESPACE"

--- a/tests/templates/kuttl/restarter/10-assert.yaml
+++ b/tests/templates/kuttl/restarter/10-assert.yaml
@@ -4,6 +4,10 @@ kind: TestAssert
 timeout: 120
 commands:
   - script: |
+      # N.B. due to breaking change https://github.com/kudobuilder/kuttl/pull/519
+      # version >=0.17 of Kuttl is required for paths to be resolved consistently.
+      # For local testing, either use nix-shell before running the test script
+      # or upgrade kuttl as needed (with e.g. kubectl krew upgrade kuttl)
       . ./test-script.sh
 
       # Wait for the StatefulSet to be deployed

--- a/tests/templates/kuttl/restarter/10-assert.yaml
+++ b/tests/templates/kuttl/restarter/10-assert.yaml
@@ -4,6 +4,12 @@ kind: TestAssert
 timeout: 120
 commands:
   - script: |
+      pwd
+
+      ls -al
+
+      tree
+
       . ./test-script.sh
 
       # Wait for the StatefulSet to be deployed

--- a/tests/templates/kuttl/restarter/10-assert.yaml
+++ b/tests/templates/kuttl/restarter/10-assert.yaml
@@ -2,11 +2,22 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 timeout: 120
----
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: test
-status:
-  readyReplicas: 1
-  replicas: 1
+commands:
+  - script: |
+      . test-script.sh
+
+      # Wait for the StatefulSet to be deployed
+      kubectl rollout status statefulset/test --namespace "$NAMESPACE"
+
+      # Check the initial status to detect some typos in the test setup
+
+      assert_revision 1 configmap-not-ignored-subpath
+      assert_revision 1 secret-not-ignored-subpath
+      assert_revision 1 configmap-self-ignored-subpath
+      assert_revision 1 secret-self-ignored-subpath
+      assert_revision 1 configmap-self-ignored
+      assert_revision 1 secret-self-ignored
+      assert_revision 1 configmap-ignored-in-statefulset-subpath
+      assert_revision 1 secret-ignored-in-statefulset-subpath
+      assert_revision 1 configmap-ignored-in-statefulset
+      assert_revision 1 secret-ignored-in-statefulset

--- a/tests/templates/kuttl/restarter/10-assert.yaml
+++ b/tests/templates/kuttl/restarter/10-assert.yaml
@@ -4,12 +4,6 @@ kind: TestAssert
 timeout: 120
 commands:
   - script: |
-      pwd
-
-      ls -al
-
-      tree
-
       . ./test-script.sh
 
       # Wait for the StatefulSet to be deployed

--- a/tests/templates/kuttl/restarter/10-create-test-resources.yaml
+++ b/tests/templates/kuttl/restarter/10-create-test-resources.yaml
@@ -17,7 +17,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: configmap-self-ignored
-  annotations:
+  labels:
     restarter.stackable.tech/ignore: "true"
 data:
   revision: "1"
@@ -26,7 +26,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: secret-self-ignored
-  annotations:
+  labels:
     restarter.stackable.tech/ignore: "true"
 stringData:
   revision: "1"
@@ -51,6 +51,7 @@ metadata:
   name: test
   labels:
     restarter.stackable.tech/enabled: "true"
+  annotations:
     restarter.stackable.tech/ignore-configmap.0: configmap-ignored-in-statefulset
     restarter.stackable.tech/ignore-secret.0: secret-ignored-in-statefulset
 spec:

--- a/tests/templates/kuttl/restarter/20-assert.yaml
+++ b/tests/templates/kuttl/restarter/20-assert.yaml
@@ -4,7 +4,7 @@ kind: TestAssert
 timeout: 180
 commands:
   - script: |
-      . test-script.sh
+      . ./test-script.sh
 
       # Wait for a possible restart of the test pod.
       # The restarter controller is expected to ignore the changes in this step, so no restart

--- a/tests/templates/kuttl/restarter/20-assert.yaml
+++ b/tests/templates/kuttl/restarter/20-assert.yaml
@@ -4,7 +4,14 @@ kind: TestAssert
 timeout: 180
 commands:
   - script: |
-      . ../../../../templates/kuttl/restarter/test-script.sh
+      . test-script.sh
+
+      # Wait for a possible restart of the test pod.
+      # The restarter controller is expected to ignore the changes in this step, so no restart
+      # should occur. However, if a restart does happen (due to a controller bug or test issue),
+      # wait here so we can verify assertions after the restart and ensure this test step fails
+      # reliably.
+      sleep 10
 
       # Resources mounted via subPath are not hot-reloaded by Kubernetes.
       # It is expected, that the restart controller ignored the annotated resources and that only

--- a/tests/templates/kuttl/restarter/21-assert.yaml
+++ b/tests/templates/kuttl/restarter/21-assert.yaml
@@ -4,7 +4,7 @@ kind: TestAssert
 timeout: 180
 commands:
   - script: |
-      . ../../../../templates/kuttl/restarter/test-script.sh
+      . test-script.sh
 
       # After a restart, all resources should have been updated.
 

--- a/tests/templates/kuttl/restarter/21-assert.yaml
+++ b/tests/templates/kuttl/restarter/21-assert.yaml
@@ -4,7 +4,7 @@ kind: TestAssert
 timeout: 180
 commands:
   - script: |
-      . test-script.sh
+      . ./test-script.sh
 
       # After a restart, all resources should have been updated.
 


### PR DESCRIPTION
## Description

Fix the restarter test:
- Use `test-script.sh` within the KUTTL `_work` directory instead of the `templates` directory.
- Fix the restarter labels and annotations; They were not effective in this test case.
- Wait for some time in the hot reloading step to ensure that the configuration changes happened due to hot-reloading and not due to a pod restart; Without this wait period, the test step succeeded most of the times. Now, it reliably fails, if e.g. labels and annotations are swapped as before.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [x] Integration tests passed:
      https://testing.stackable.tech/job/commons-operator-it-custom/47/

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
