### PR TITLE
chore: crds are installed by the operator

### DIFF
--- a/docs/modules/commons-operator/pages/installation.adoc
+++ b/docs/modules/commons-operator/pages/installation.adoc
@@ -56,6 +56,7 @@ Install the Stackable Commons Operator
 $ helm install --wait commons-operator \
   oci://oci.stackable.tech/sdp-charts/commons-operator --version 24.7.0
 
-Helm will deploy the operator in Kubernetes and apply the CRDs.
+Helm will deploy the operator in Kubernetes.
+The operator installs and maintains its own CRDs at startup (see xref:concepts:maintenance/crds.adoc[]).
 --
 ====


### PR DESCRIPTION
## Description

As of 26.3 all operators manage their CRDs - this was not unambiguously reflected in the docs.