### PR TITLE
fix: Remove the hardcoded image repository from values.yaml

### DIFF
--- a/deploy/helm/commons-operator/values.yaml
+++ b/deploy/helm/commons-operator/values.yaml
@@ -1,7 +1,6 @@
 # Default values for commons-operator.
 ---
 image:
-  repository: oci.stackable.tech/sdp/commons-operator
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
## Description

I'm looking into adding a [Values schema](https://helm.sh/docs/topics/charts/#schema-files) and had Claude analyse our values file. commons-operator is the only one setting `image.repository` in its own values file.  The others leave it to the registry overlay in deploy/helm/commons-operator/values/.

In addition the value was also wrong. So, due to the overlay this is not actively broken but its still better to be consistent I think.

No behaviour change for published charts as the overlay wins anyway.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
